### PR TITLE
Adicionando métodos de pesquisa para funcionários

### DIFF
--- a/src/main/java/com/pss/presenter/ListarFuncionariosPresenter.java
+++ b/src/main/java/com/pss/presenter/ListarFuncionariosPresenter.java
@@ -2,11 +2,14 @@ package com.pss.presenter;
 
 import com.pss.model.Funcionario;
 import com.pss.view.ListarFuncionariosView;
+
 import com.pss.collection.FuncionarioCollection;
 
+import java.awt.event.KeyListener;
+import java.awt.event.KeyEvent;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
+import java.util.ArrayList;
 import java.util.Vector;
 
 import javax.swing.JOptionPane;
@@ -19,6 +22,9 @@ public class ListarFuncionariosPresenter extends BasePresenter {
         this.getFilhoView().getBotaoEditar().addActionListener(this.clickBotaoEditar());
         this.getFilhoView().getBotaoVisualizar().addActionListener(this.clickBotaoVisualizar());
         this.getFilhoView().getBotaoExcluir().addActionListener(this.clickBotaoExcluir());
+        this.getFilhoView().getBotaoPesquisar().addActionListener(this.clickBotaoPesquisar());
+
+        this.getFilhoView().getCampoPesquisa().addKeyListener(this.pesquisarEnter());
     }
 
     @Override
@@ -108,6 +114,56 @@ public class ListarFuncionariosPresenter extends BasePresenter {
         };
     }
 
+    private final void filtrarFuncionarios() {
+        ArrayList<Funcionario> funcionarios = FuncionarioCollection.getInstancia().getFuncionarios();
+        ArrayList<Funcionario> funcionariosFiltrados = new ArrayList<>();
+
+        String filtro = (
+            String.format(
+                ".*%s.*",
+                this.getFilhoView().getCampoPesquisa().getText().trim().toLowerCase()
+            )
+        );
+
+        for (Funcionario f : funcionarios) {
+            if ((f.getNome() + f.getCargo()).matches(filtro)) {
+                funcionariosFiltrados.add(f);
+            }
+        }
+
+        this.atualizarTabela(funcionariosFiltrados);
+    }
+
+    private final ActionListener clickBotaoPesquisar() {
+        ListarFuncionariosPresenter thisObject = this;
+        
+        return new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                thisObject.filtrarFuncionarios();
+            }
+        };
+    }
+
+    private final KeyListener pesquisarEnter() {
+        ListarFuncionariosPresenter thisObject = this;
+        
+        return new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+                if (e.getKeyChar() == KeyEvent.VK_ENTER) {
+                    thisObject.filtrarFuncionarios();
+                }
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {}
+
+            @Override
+            public void keyReleased(KeyEvent e) {}
+        };
+    }
+
     public void limparTabela() {
         DefaultTableModel dtm = this.getFilhoView().getTabelaModel();
 
@@ -118,16 +174,19 @@ public class ListarFuncionariosPresenter extends BasePresenter {
         this.getPrincipalPresenter().getJanela().revalidate();
     }
 
-    public void atualizarTabela() {
+    public void atualizarTabela(ArrayList<Funcionario> funcionarios) {
         DefaultTableModel dtm = this.getFilhoView().getTabelaModel();
-        FuncionarioCollection funcionarios = FuncionarioCollection.getInstancia();
+
+        if (funcionarios == null) {
+            funcionarios = FuncionarioCollection.getInstancia().getFuncionarios();
+        }
         
         if (dtm.getRowCount() > 0) {
             this.limparTabela();
         }
         
         Integer i = 0;
-        for (Funcionario f : funcionarios.getFuncionarios()) {
+        for (Funcionario f : funcionarios) {
             Vector<Object> rowData = new Vector<>(dtm.getColumnCount());
             
             rowData.add(i + 1);

--- a/src/main/java/com/pss/presenter/PrincipalPresenter.java
+++ b/src/main/java/com/pss/presenter/PrincipalPresenter.java
@@ -75,7 +75,7 @@ public class PrincipalPresenter extends BasePresenter {
     
     public void vaParaConsultarFuncionarios() {
         ListarFuncionariosPresenter lfp = this.listarFuncionariosPresenter;
-        lfp.atualizarTabela();
+        lfp.atualizarTabela(null);
         this.vaPara(lfp.getFilhoView());
     }
 

--- a/src/main/java/com/pss/view/ListarFuncionariosView.java
+++ b/src/main/java/com/pss/view/ListarFuncionariosView.java
@@ -4,23 +4,37 @@ import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.JTextField;
+
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.DefaultTableModel;
 
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
+import java.awt.Dimension;
 
 public class ListarFuncionariosView extends BaseView {
     private JTable tabela;
     private DefaultTableModel tabelaModel;
     private TableColumnModel colunasModel;
 
+    private JTextField campoPesquisa;
+
     private JButton botaoEditar;
     private JButton botaoVisualizar;
     private JButton botaoExcluir;
+    private JButton botaoPesquisar;
 
     public ListarFuncionariosView() {
         super(new BorderLayout());
+
+        JPanel painelPesquisa = new JPanel(new BorderLayout());
+        this.campoPesquisa = new JTextField(20);
+        this.campoPesquisa.setPreferredSize(new Dimension(300, 30));
+        painelPesquisa.add(this.campoPesquisa, BorderLayout.CENTER);
+
+        this.botaoPesquisar = new JButton("Pesquisar");
+        painelPesquisa.add(this.botaoPesquisar, BorderLayout.EAST);
 
         DefaultTableModel tableModel = new DefaultTableModel() {
             @Override
@@ -40,18 +54,24 @@ public class ListarFuncionariosView extends BaseView {
         this.tabelaModel = tableModel;
 
         JScrollPane scrollPane = new JScrollPane(tabela);
-        this.add(scrollPane, BorderLayout.CENTER);
-
+        
         JPanel botoesPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
         
         this.botaoEditar = new JButton("Editar");
-        this.botaoVisualizar = new JButton("Ver");
-        this.botaoExcluir = new JButton("Excluir");
+        this.botaoEditar.setPreferredSize(new Dimension(100, 30));
 
+        this.botaoVisualizar = new JButton("Ver");
+        this.botaoVisualizar.setPreferredSize(new Dimension(100, 30));
+
+        this.botaoExcluir = new JButton("Excluir");
+        this.botaoExcluir.setPreferredSize(new Dimension(100, 30));
+        
         botoesPanel.add(botaoEditar);
         botoesPanel.add(botaoVisualizar);
         botoesPanel.add(botaoExcluir);
-
+        
+        this.add(painelPesquisa, BorderLayout.NORTH);
+        this.add(scrollPane, BorderLayout.CENTER);
         this.add(botoesPanel, BorderLayout.SOUTH);
     }
 
@@ -77,5 +97,13 @@ public class ListarFuncionariosView extends BaseView {
 
     public JButton getBotaoVisualizar() {
         return this.botaoVisualizar;
+    }
+
+    public JTextField getCampoPesquisa() {
+        return this.campoPesquisa;
+    }
+
+    public JButton getBotaoPesquisar() {
+        return this.botaoPesquisar;
     }
 }

--- a/src/main/java/com/pss/view/ListarFuncionariosView.java
+++ b/src/main/java/com/pss/view/ListarFuncionariosView.java
@@ -53,9 +53,6 @@ public class ListarFuncionariosView extends BaseView {
         botoesPanel.add(botaoExcluir);
 
         this.add(botoesPanel, BorderLayout.SOUTH);
-
-        this.colunasModel.getColumn(0).setPreferredWidth(5);
-        // this.tabela.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
     }
 
     public JTable getTabela() {


### PR DESCRIPTION
Foi adicionado à tela `Consultar Funcionário` uma barra de pesquisa e um botão `Pesquisar`

- Em relação a pesquisa:
  - Consiste em filtrar os funcionários de a cordo com o que está digitado na barra de pesquisa;
  - É realizada ao precionar `ENTER` na barra de pesquisa ou clicar no botão `Pesquisar`;
  - É utilizado o regex `.*%s.*` onde o `%s` é substituído pelo valor presente na barra de pesquisa;
  - Os campos utilizados são `Nome` e `Cargo`.


![image](https://github.com/EmployingDGC/funcionario-mvp-pss/assets/63275906/5d7fca5a-001f-480c-88da-804d98cc1128)
